### PR TITLE
Fixed package imports for python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scLVM
 
-## This is a version of scLVM with fixed imports
-You need a conda environment with python 3.10, pip, numpy and limix-legacy. Install scLVM from github by first forking, and then running "pip install ." inside the repo. However, some parameter changes are not fixed yet.
+## This is a version of scLVM with fixed imports for python 3.10, however it still needs some attention and love.
+You need a conda environment with python 3.10, pip, numpy and limix-legacy. Install scLVM from github by first forking, and then running "pip install ." inside the repo. However, some parameter changes are not fixed yet. Do not install scLVM via pip, that version is not working.
 
 ## What is scLVM?
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # scLVM
 
+## This is a version of scLVM with fixed imports
+You need a conda environment with python 3.10, pip, numpy and limix-legacy. Install scLVM from github by first forking, and then running "pip install ." inside the repo. However, some parameter changes are not fixed yet.
 
 ## What is scLVM?
 

--- a/scLVM/core.py
+++ b/scLVM/core.py
@@ -17,9 +17,9 @@ from __future__ import division, print_function, absolute_import
 import sys
 #import limix #make sure we use the right limix version
 
-from utils.misc import dumpDictHdf5
-from utils.misc import PCA 
-from utils.misc import warning_on_one_line 
+from .utils.misc import dumpDictHdf5
+from .utils.misc import PCA 
+from .utils.misc import warning_on_one_line 
 import limix_legacy
 
 import limix_legacy.deprecated.modules.panama as PANAMA


### PR DESCRIPTION
The existing version of scLVM on github and pip are not functioning. Here, I fixed the package imports. Open are at least fixes for parameter changes for some functions.